### PR TITLE
Add minimum version of pytest with coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,9 @@ develop:
 docs:
 	poetry run sphinx-apidoc -f -o docs src/cltkv1 && cd docs && poetry run make html && cd ..
 
-freeze:
-	# Equivalent of ``pip uninstall -y cltk && pip freeze > requirements-dev.txt``
-	poetry update
-
 install:
+	# Equivalent of ``python setup.py install``
+	# Equivalent of ``pip install -r requirements.txt``
 	poetry install
 
 installPyPITest:
@@ -23,16 +21,17 @@ installPyPITest:
 lint:
 	mkdir pylint && poetry run pylint --output-format=json cltkv1 > pylint/pylint.json || true && poetry run pylint-json2html pylint/pylint.json 1> pylint/pylint.html
 
-requirements:
-	# Equivalent of ``pip install -r requirements.txt``
-	poetry update
-
 test:
 	# poetry run nosetests --no-skip --with-coverage --cover-erase --cover-html-dir=htmlcov --cover-html --cover-package=cltkv1 --with-doctest
 	poetry run tox
 
 typing:
 	mypy --html-report .mypy_cache cltk
+
+updateDependencies:
+	# Installs the packages installed with ``poetry add <package-name>`` and entered into ``pyproject.toml``
+	# Equivalent of ``pip install -r requirements.txt``
+	poetry update
 
 uml:
 	cd docs && pyreverse -o png ../cltk

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = "Classical Language Toolkit"
+project = "The Classical Language Toolkit"
 copyright = '2019, "Kyle P. Johnson <kyle@kyle-p-johnson.com>"'
 author = '"Kyle P. Johnson <kyle@kyle-p-johnson.com>"'
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -479,6 +479,18 @@ six = ">=1.10.0"
 
 [[package]]
 category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.7.1"
+
+[package.dependencies]
+coverage = ">=4.4"
+pytest = ">=3.6"
+
+[[package]]
+category = "dev"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
@@ -733,8 +745,8 @@ python-versions = ">=2.7"
 version = "0.5.2"
 
 [metadata]
-content-hash = "6a2e48aa25a27decbc9d3ad525ee4f2c4de940ddfbb7df776ad1bbd4a3ddedc0"
-python-versions = "^3.7"
+content-hash = "411cae0235ab7c58098f278f1f7072ecff5312745e4d77683ebba89649fde253"
+python-versions = "^3.6"
 
 [metadata.hashes]
 alabaster = ["446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359", "a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"]
@@ -786,6 +798,7 @@ pylint = ["5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09", "7
 pylint-json2html = ["a782422abeee0985ce4381c7e00e2621511d2eda054b133772c5d6579fc1ae5d", "b6965ba96f5fe4981f74e70b41c0a98fa635addce3ea45d6db9a9983a0c00aa3"]
 pyparsing = ["6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80", "d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"]
 pytest = ["3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec", "e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"]
+pytest-cov = ["2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6", "e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"]
 pytz = ["26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32", "c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ include = []
 exclude = []
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.6"
 gitpython = "^3.0"
 stanfordnlp = "^0.2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ pylint-json2html = "^0.1.0"
 isort = "^4.3"
 tox = "^3.13"
 tox-pyenv = "^1.1"
+pytest-cov = "^2.7"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ deps =
 whitelist_externals = poetry
 commands =
     poetry install -v
-    poetry run pytest --doctest-modules src/cltkv1/
+    poetry run pytest --doctest-modules --cov-report term-missing --cov-report html:htmlcov --cov=src/cltkv1 src/cltkv1/ tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,11 @@
 
 [tox]
 isolated_build = true
-envlist = py37
+envlist = py36,py37
 
 [testenv]
 deps =
     pytest
-;commands =
-;    pytest
 whitelist_externals = poetry
 commands =
     poetry install -v


### PR DESCRIPTION
``` shell
$ poetry run pytest --doctest-modules --cov-report term-missing --cov-report html:htmlcov --cov=src/cltkv1 src/cltkv1/ tests
============================= test session starts ==============================
platform darwin -- Python 3.7.4, pytest-3.10.1, py-1.8.0, pluggy-0.12.0
rootdir: /Users/kyle, inifile:
plugins: cov-2.7.1
collected 25 items                                                             

src/cltkv1/nlp.py ....                                                   [ 16%]
src/cltkv1/dependency/stanford.py ......                                 [ 40%]
src/cltkv1/tokenizers/tokenizers.py ...                                  [ 52%]
src/cltkv1/utils/utils.py ...                                            [ 64%]
src/cltkv1/wrappers/stanford.py ........                                 [ 96%]
tests/test_cltkv1.py .                                                   [100%]

---------- coverage: platform darwin, python 3.7.4-final-0 -----------
Name                                  Stmts   Miss  Cover   Missing
-------------------------------------------------------------------
src/cltkv1/__init__.py                    2      0   100%
src/cltkv1/codes/__init__.py              0      0   100%
src/cltkv1/codes/glottolog.py            47     40    15%   1700-1774
src/cltkv1/dependency/__init__.py         1      0   100%
src/cltkv1/dependency/stanford.py        87     41    53%   65-67, 83-84, 168-170, 173, 180-182, 189-191, 194-197, 203-205, 208-213, 220, 225-237, 249-252
src/cltkv1/nlp.py                        34     20    41%   107-143
src/cltkv1/tokenizers/__init__.py         1      0   100%
src/cltkv1/tokenizers/tokenizers.py      16      0   100%
src/cltkv1/utils/__init__.py              2      0   100%
src/cltkv1/utils/build_server.py          6      3    50%   12-23
src/cltkv1/utils/exceptions.py            1      0   100%
src/cltkv1/utils/utils.py                28      0   100%
src/cltkv1/wrappers/__init__.py           1      0   100%
src/cltkv1/wrappers/stanford.py         104     53    49%   71, 86, 161, 173-192, 219, 245-246, 252-253, 258-298
-------------------------------------------------------------------
TOTAL                                   330    157    52%
Coverage HTML written to dir htmlcov


=============================== warnings summary ===============================
cltkv1/src/cltkv1/nlp.py::cltkv1.nlp.NLP._parse_stanford
  ../aten/src/ATen/native/LegacyDefinitions.cpp:14: UserWarning: masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated,please use a mask with dtype torch.bool instead.

cltkv1/src/cltkv1/dependency/stanford.py::cltkv1.dependency.stanford.Form.to_form
  ../aten/src/ATen/native/LegacyDefinitions.cpp:14: UserWarning: masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated,please use a mask with dtype torch.bool instead.

cltkv1/src/cltkv1/wrappers/stanford.py::cltkv1.wrappers.stanford.StanfordNLPWrapper.__init__
  ../aten/src/ATen/native/LegacyDefinitions.cpp:14: UserWarning: masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated,please use a mask with dtype torch.bool instead.

cltkv1/src/cltkv1/wrappers/stanford.py::cltkv1.wrappers.stanford.StanfordNLPWrapper.parse
  ../aten/src/ATen/native/LegacyDefinitions.cpp:14: UserWarning: masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated,please use a mask with dtype torch.bool instead.

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 25 passed, 4 warnings in 31.72 seconds ====================

```